### PR TITLE
add a screenreader only describedby div

### DIFF
--- a/example/styles.css
+++ b/example/styles.css
@@ -189,3 +189,14 @@ body {
   align-items: center;
   padding-right: 6px;
 }
+
+.ic-token-screenreader-only {
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,9 @@ module.exports = React.createClass({
     selected: React.PropTypes.array.isRequired,
     menuContent: React.PropTypes.any,
     showListOnFocus: React.PropTypes.bool,
-    placeholder: React.PropTypes.string
+    placeholder: React.PropTypes.string,
+    describedby: React.PropTypes.string,
+    describedbyId: React.PropTypes.string
   },
 
   getInitialState: function() {
@@ -61,7 +63,8 @@ module.exports = React.createClass({
           onRemove: this.handleRemove,
           value: token,
           name: token.name,
-          key: token.id})
+          key: token.id,
+          describedbyId: this.props.describedbyId})
       )
     }.bind(this))
 
@@ -87,7 +90,8 @@ module.exports = React.createClass({
           this.props.menuContent
         )
       ),
-      this.props.isLoading && li({className: 'ic-tokeninput-loading flex'}, this.props.loadingComponent)
+      this.props.isLoading && li({className: 'ic-tokeninput-loading flex'}, this.props.loadingComponent),
+      div({id: this.props.describedbyId, className: 'ic-token-screenreader-only'}, this.props.describedby)
     );
   }
 })

--- a/lib/token.js
+++ b/lib/token.js
@@ -3,6 +3,9 @@ var span = React.DOM.span;
 var li = React.createFactory('li');
 
 module.exports = React.createClass({
+  propTypes: {
+    describedbyId: PropTypes.string.isRequired
+  },
   handleClick: function() {
     this.props.onRemove(this.props.value)
   },
@@ -22,6 +25,7 @@ module.exports = React.createClass({
           onClick: this.handleClick,
           onKeyDown: this.handleKeyDown,
           'aria-label': 'Remove \'' + this.props.name + '\'',
+          'aria-describedby': this.props.describedbyId,
           className: "ic-token-delete-button",
           tabIndex: 0
         }, "✕"),


### PR DESCRIPTION
This allows non visual users to have a description of the fields they
are using. This is extremely helpful for understanding the context in
which you're working. Because everything is being passed in, the
consuming app can define exactly how they would like to convay their
field. It also allows them to easily drop in any the appropriate text
for the appropriate translation.
